### PR TITLE
2.9.5 remove noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<38]
@@ -38,7 +37,7 @@ test:
   commands:
     - pip check
     - pytest unyt/tests -v
-    
+
 about:
   home: https://github.com/yt-project/unyt
   license: BSD-3-Clause


### PR DESCRIPTION
Re-using build 0 as it was never deployed.